### PR TITLE
README.md: Add packages in the AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-
 ![](Art/preview.png)
 
 #### Installation
-
 Extract the zip file to the themes directory i.e. `/usr/share/themes/` or `~/.themes/` (create it if necessary).
 
-To set the theme on Gnome, run the following commands in Terminal:
+or if you are using Arch Linux based distrobutions install from the [AUR](https://aur.archlinux.org/packages/?O=0&K=juno-):
+```
+YOUR_AUR_HELPER -S juno-ocean-standard-buttons-theme-git
+```
 
+To set the theme on Gnome, run the following commands in Terminal:
 ```
 gsettings set org.gnome.desktop.interface gtk-theme "Juno"
 gsettings set org.gnome.desktop.wm.preferences theme "Juno"
 ```
 or Change via distribution specific tool.
-


### PR DESCRIPTION
I've packaged your epic themes for Arch Linux and they are available in the [AUR](https://aur.archlinux.org/packages/?O=0&K=juno-)

